### PR TITLE
Remove outdated documentation, replace with links

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,29 +1,5 @@
-If you would like to contribute, please open a ticket in JIRA:
+If you would like to contribute, please see
 
-* http://tickets.chef.io
+* https://docs.chef.io/community_contributions.html
 
-Create the ticket in the COOK project and use the cookbook name as the
-component.
-
-For all code contributions, we ask that contributors sign a
-contributor license agreement (CLA). Instructions may be found here:
-
-* http://wiki.chef.io/display/chef/How+to+Contribute
-
-When contributing changes to individual cookbooks, please do not
-modify the version number in the metadata.rb. Also please do not
-update the CHANGELOG.md for a new version. Not all changes to a
-cookbook may be merged and released in the same versions. Chef Software will
-handle the version updates during the release process. You are welcome
-to correct typos or otherwise make updates to documentation in the
-README.
-
-If a contribution adds new platforms or platform versions, indicate
-such in the body of the commit message(s), and update the relevant
-COOK ticket. When writing commit messages, it is helpful for others if
-you indicate the COOK ticket. For example:
-
-    git commit -m '[COOK-1041] Updated pool resource to correctly delete.'
-
-In the ticket itself, it is also helpful if you include log output of
-a successful Chef run, but this is not absolutely required.
+* https://github.com/chef/chef/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Previous content was outdated and incorrect, and had several broken links.
Rather than copy or create updated information (which will become outdated), replace with links to documentation and CONTRIBUTING.md for Chef itself (assuming that with two unrelated links we increase the likelihood that one of them will still work in the future).